### PR TITLE
Fix type package name erasure due to name collision

### DIFF
--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -70,6 +70,32 @@ func TestMoqExplicitPackage(t *testing.T) {
 	}
 }
 
+func TestMoqExplicitPackageSameName(t *testing.T) {
+	m, err := New("testpackages/samepackagename", "")
+	if err != nil {
+		t.Fatalf("moq.New: %s", err)
+	}
+	var buf bytes.Buffer
+	err = m.Mock(&buf, "PersonStore")
+	if err != nil {
+		t.Errorf("m.Mock: %s", err)
+	}
+	s := buf.String()
+	// assertions of things that should be mentioned
+	var strs = []string{
+		"package same",
+		"CreateFunc func(ctx context.Context, person *same.Person, confirm bool) error",
+		"GetFunc func(ctx context.Context, id string) (*same.Person, error)",
+		"func (mock *PersonStoreMock) Create(ctx context.Context, person *same.Person, confirm bool) error",
+		"func (mock *PersonStoreMock) Get(ctx context.Context, id string) (*same.Person, error)",
+	}
+	for _, str := range strs {
+		if !strings.Contains(s, str) {
+			t.Errorf("expected but missing: \"%s\"", str)
+		}
+	}
+}
+
 // TestVeradicArguments tests to ensure variadic work as
 // expected.
 // see https://github.com/matryer/moq/issues/5

--- a/pkg/moq/testpackages/samepackagename/example.go
+++ b/pkg/moq/testpackages/samepackagename/example.go
@@ -1,0 +1,14 @@
+package same
+
+import (
+	"context"
+
+	"github.com/betalo-sweden/moq/pkg/moq/testpackages/samepackagename/same"
+)
+
+// PersonStore stores people.
+type PersonStore interface {
+	Get(ctx context.Context, id string) (*same.Person, error)
+	Create(ctx context.Context, person *same.Person, confirm bool) error
+	ClearCache(id string)
+}

--- a/pkg/moq/testpackages/samepackagename/same/person.go
+++ b/pkg/moq/testpackages/samepackagename/same/person.go
@@ -1,0 +1,9 @@
+package same
+
+// Person is a person.
+type Person struct {
+	ID      string
+	Name    string
+	Company string
+	Website string
+}


### PR DESCRIPTION
This does still not perfectly work for all cases (e.g. when the output file is in a different directory), but it should work better than the current implementation.

Fixes #4.