### PR TITLE
Allow empty GOPATH

### DIFF
--- a/pkg/moq/moq.go
+++ b/pkg/moq/moq.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
+	"go/build"
 	"go/parser"
 	"go/token"
 	"go/types"
@@ -359,6 +360,9 @@ func stripGopath(p string) string {
 	return p
 }
 
+// gopaths returns a list of GOPATH paths.
+//
+// See https://github.com/golang/go/blob/master/src/cmd/go/internal/envcmd/env.go#L58
 func gopaths() []string {
-	return strings.Split(os.Getenv("GOPATH"), string(filepath.ListSeparator))
+	return filepath.SplitList(build.Default.GOPATH)
 }


### PR DESCRIPTION
This is a new feature since Go 1.9, which sets the GOPATH to `$HOME/go` if the environment variable `GOPATH` is not set.

The implementation is also simplified by using the stdlib API `filepath.SplitList`. As a side-effect this should also be (a bit) faster as we don't have to consult the environment variables.