### PR TITLE
Avoid self-import cycle when package and folder are named differently

### DIFF
--- a/pkg/moq/moq.go
+++ b/pkg/moq/moq.go
@@ -189,7 +189,9 @@ func (m *Mocker) Mock(w io.Writer, name ...string) error {
 
 func (m *Mocker) packageQualifier(pkg *types.Package) string {
 	path := pkg.Path()
-	if path == m.pkgPath {
+	importPath := filepath.Join(filepath.Dir(path), pkg.Name())
+
+	if importPath == m.pkgPath {
 		return ""
 	}
 	if path == "." {

--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -96,6 +96,42 @@ func TestMoqExplicitPackageSameName(t *testing.T) {
 	}
 }
 
+func TestMoqPackageAndFolderNamedDifferently(t *testing.T) {
+	m, err := New("testpackages/package_named_differently_from_folder", "")
+	if err != nil {
+		t.Fatalf("moq.New: %s", err)
+	}
+	var buf bytes.Buffer
+	err = m.Mock(&buf, "PersonStore")
+	if err != nil {
+		t.Errorf("m.Mock: %s", err)
+	}
+	s := buf.String()
+
+	// assertions of things that should be mentioned
+	var shouldBeMentioned = []string{
+		"GetFunc func() *Person",
+		"func (mock *PersonStoreMock) Get() *Person",
+	}
+	for _, str := range shouldBeMentioned {
+		if !strings.Contains(s, str) {
+			t.Errorf("expected but missing: \"%s\"", str)
+		}
+	}
+
+	// assertions of things that should not be mentioned
+	var shouldNotBeMentioned = []string{
+		"github.com/betalo-sweden/moq/pkg/moq/testpackages/package_named_differently_from_folder",
+		"GetFunc: func() *p.Person",
+		"func (mock *PersonStoreMock) Get() *p.Person",
+	}
+	for _, str := range shouldNotBeMentioned {
+		if strings.Contains(s, str) {
+			t.Errorf("not expected but found: \"%s\"", str)
+		}
+	}
+}
+
 // TestVeradicArguments tests to ensure variadic work as
 // expected.
 // see https://github.com/matryer/moq/issues/5

--- a/pkg/moq/testpackages/package_named_differently_from_folder/example.go
+++ b/pkg/moq/testpackages/package_named_differently_from_folder/example.go
@@ -1,0 +1,14 @@
+package p
+
+// PersonStore stores people.
+type PersonStore interface {
+	Get() *Person
+}
+
+// Person is a person.
+type Person struct {
+	ID      string
+	Name    string
+	Company string
+	Website string
+}


### PR DESCRIPTION
Maybe we shouldn't be naming packages and folders differently, but Go supports it and so did Moq up until https://github.com/betalo-sweden/moq/pull/5.

This is currently causing a problem in other projects.